### PR TITLE
Fix Typo For the Invalid Repo Error Message

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -75,7 +75,7 @@ export default {
         this.btntext = "refresh"
       }).catch((err) => {
         this.errorActive = true
-        this.error = `Faild to create link card. Please make sure ${this.name} exits`
+        this.error = `Faild to create link card. Please make sure ${this.name} exists`
         this.btntext = "refresh"
       })
     },


### PR DESCRIPTION
I think this is pretty much Understandable.

`exits` => `exists`

<img width="549" alt="Screenshot 2021-03-05 at 1 39 16 PM" src="https://user-images.githubusercontent.com/61158210/110086285-2f8a9d80-7db8-11eb-8267-82e5385d2864.png">
